### PR TITLE
Update SampleBufferTransformer to invert colors

### DIFF
--- a/IrisCamera/Sources/IrisCamera/Internal/SampleBufferTransformer.swift
+++ b/IrisCamera/Sources/IrisCamera/Internal/SampleBufferTransformer.swift
@@ -4,15 +4,30 @@ import Foundation
 
 struct SampleBufferTransformer {
     func transform(videoSampleBuffer: CMSampleBuffer) -> CMSampleBuffer {
-        guard let pixelBuffer = CMSampleBufferGetImageBuffer(videoSampleBuffer) else {
+        guard let imageBuffer = CMSampleBufferGetImageBuffer(videoSampleBuffer) else {
             print("failed to get pixel buffer")
             fatalError()
         }
+        
+        let context = CIContext(options: nil)
+        let filter = "CIColorInvert"
 
-        #warning("Implementation to invert colors in pixel buffer")
+        // CIImage from buffer
+        let ciImage = CIImage(cvImageBuffer: imageBuffer)
 
+        // Invert the colors
+        let ciImageInverted = ciImage.applyingFilter(filter, parameters: [:])
 
-        guard let result = try? pixelBuffer.mapToSampleBuffer(timestamp: videoSampleBuffer.presentationTimeStamp) else {
+        // Lock the buffer
+        CVPixelBufferLockBaseAddress(imageBuffer, CVPixelBufferLockFlags(rawValue: 0))
+
+        // Render the inverted CIImage into the buffer
+        context.render(ciImageInverted, to: imageBuffer)
+
+        // Unlock the buffer
+        CVPixelBufferUnlockBaseAddress(imageBuffer, CVPixelBufferLockFlags(rawValue: 0))
+
+        guard let result = try? imageBuffer.mapToSampleBuffer(timestamp: videoSampleBuffer.presentationTimeStamp) else {
             fatalError()
         }
 


### PR DESCRIPTION
I was not in touch a lot with CoreImage API before, so when I read the task I got 2 ideas in my head. 
The first idea was to apply some kind of filter or the second idea was to get access to the pixels and modify pixel by pixel. 
I decided to go with the first idea because I thought it would be simpler and more readable since the second solution would require more in-depth knowledge of pixel manipulations and  I would probably use it if there is some extraordinary performance optimization needed. 
My solution is simple, it creates CIIImage from the buffer provided and applies CIColorInvert on it. After that, it renders the inverted image on the buffer and returns the modified buffer.
There are probably some better solutions, but considering my previous experience with this API and the documentation I managed to dig up, I think it works fine. 
Generally in the code, I would maybe try to hide some implementation details, especially in CapturePipeline to make it more testable, also the AVCaptureSession could be injected, but that is not the scope of the task. 